### PR TITLE
Druid service 객체 에러 해결

### DIFF
--- a/.github/workflows/test-go-code.yml
+++ b/.github/workflows/test-go-code.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - 'release/**'
+      - 'hotfix/**'
   pull_request:
     branches:
       - master

--- a/.github/workflows/test-go-code.yml
+++ b/.github/workflows/test-go-code.yml
@@ -1,0 +1,27 @@
+name: test-go-code
+on:
+  push:
+    - branches:
+      - master
+      - 'release/**'
+  pull_request:
+    - branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+  steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.16.5'
+
+    - name: Install dependencies
+      run: go mod tidy -v
+
+    - name: Build go binary
+      run: go build -v ./...
+    
+    - name: Test go code
+      run: go test -v ./...

--- a/.github/workflows/test-go-code.yml
+++ b/.github/workflows/test-go-code.yml
@@ -1,11 +1,11 @@
 name: test-go-code
 on:
   push:
-    - branches:
+    branches:
       - master
       - 'release/**'
   pull_request:
-    - branches:
+    branches:
       - master
 jobs:
   test:

--- a/.github/workflows/test-go-code.yml
+++ b/.github/workflows/test-go-code.yml
@@ -17,6 +17,15 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.16.5'
+    
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Install dependencies
       run: go mod tidy -v

--- a/.github/workflows/test-go-code.yml
+++ b/.github/workflows/test-go-code.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-20.04
-  steps:
+    steps:
     - uses: actions/checkout@v2
 
     - uses: actions/setup-go@v2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Druid Manager
 
+![test-go-code](https://github.com/humit0/druid_manager/actions/workflows/test-go-code.yml/badge.svg)
+
 ## 소개
 
 Druid에 대한 내용을 모니터링 및 여러 내용을 관리하기 위한 서버입니다.

--- a/internal/druid_broker/broker.go
+++ b/internal/druid_broker/broker.go
@@ -10,5 +10,5 @@ var (
 )
 
 type BrokerServiceImp struct {
-	DruidClient druid.DruidClient
+	DruidClient *druid.DruidClient
 }

--- a/internal/druid_coordinator/coordinator.go
+++ b/internal/druid_coordinator/coordinator.go
@@ -13,5 +13,5 @@ var (
 )
 
 type CoordinatorServiceImp struct {
-	DruidClient druid.DruidClient
+	DruidClient *druid.DruidClient
 }

--- a/internal/druid_historical/historical.go
+++ b/internal/druid_historical/historical.go
@@ -12,5 +12,5 @@ var (
 )
 
 type HistoricalServiceImp struct {
-	DruidClient druid.DruidClient
+	DruidClient *druid.DruidClient
 }

--- a/internal/druid_middle_manager/middle_manager.go
+++ b/internal/druid_middle_manager/middle_manager.go
@@ -10,5 +10,5 @@ var (
 )
 
 type MiddleManagerServiceImp struct {
-	DruidClient druid.DruidClient
+	DruidClient *druid.DruidClient
 }

--- a/internal/druid_overlord/overlord.go
+++ b/internal/druid_overlord/overlord.go
@@ -13,5 +13,5 @@ var (
 )
 
 type OverlordServiceImp struct {
-	DruidClient druid.DruidClient
+	DruidClient *druid.DruidClient
 }


### PR DESCRIPTION
Druid 서비스 객체에서 `druidClient` 객체가 복사되어 발생하는 오류를 수정
resolve #5